### PR TITLE
Fix security

### DIFF
--- a/app/controllers/scriptures_controller.rb
+++ b/app/controllers/scriptures_controller.rb
@@ -17,12 +17,18 @@ class ScripturesController < ApplicationController
 
   component_class_template 'Scriptures::%{type}PageComponent'
 
-  def new
-    @record = scope.new(parent_id: params[:parent_id])
-    render form_component(record)
+  private
+
+  def form_component(record)
+    record.parent_id = parent_id
+    super(record)
   end
 
-  private
+  def parent_id
+    if params[:parent_id]
+      current_user.scriptures.find(params[:parent_id])
+    end
+  end
 
   def per_page
     params[:per].presence || 200

--- a/lib/url_acl.rb
+++ b/lib/url_acl.rb
@@ -6,7 +6,9 @@ class UrlAcl
   PUBLIC_URLS = [
     '/',
     '/logout',
-    '/profile'
+    '/profile',
+    '/:profile/scriptures',
+    '/:profile/timelines'
   ].freeze
 
   def initialize(url)
@@ -14,7 +16,9 @@ class UrlAcl
   end
 
   def authorized?(user)
-    if PUBLIC_URLS.include?(@url)
+    url = @url.sub(user.username.to_s, ':profile')
+
+    if PUBLIC_URLS.include?(url)
       return true
     end
 

--- a/spec/requests/scriptures_request_spec.rb
+++ b/spec/requests/scriptures_request_spec.rb
@@ -101,6 +101,12 @@ RSpec.describe ScripturesController, type: :request do
       )
       expect(renderer).to have_rendered_component(expected_component)
     end
+
+    it 'responds with 404 if parent id does not belong to the user' do
+      get(new_path, params: { parent_id: factory.scriptures.create.id })
+
+      expect(response).to have_http_status(404)
+    end
   end
 
   describe 'POST #create' do
@@ -179,6 +185,12 @@ RSpec.describe ScripturesController, type: :request do
         profile_owner: current_user
       )
       expect(renderer).to have_rendered_component(expected_component)
+    end
+
+    it 'responds with 404 if parent id does not belong to the user' do
+      get(edit_path, params: { parent_id: factory.scriptures.create.id })
+
+      expect(response).to have_http_status(404)
     end
   end
 

--- a/spec/requests/scriptures_request_spec.rb
+++ b/spec/requests/scriptures_request_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe ScripturesController, type: :request do
     it 'responds with 404 if parent id does not belong to the user' do
       get(new_path, params: { parent_id: factory.scriptures.create.id })
 
-      expect(response).to have_http_status(404)
+      expect(response).to have_http_status(:not_found)
     end
   end
 
@@ -190,7 +190,7 @@ RSpec.describe ScripturesController, type: :request do
     it 'responds with 404 if parent id does not belong to the user' do
       get(edit_path, params: { parent_id: factory.scriptures.create.id })
 
-      expect(response).to have_http_status(404)
+      expect(response).to have_http_status(:not_found)
     end
   end
 


### PR DESCRIPTION
- Show 404 when scripture parent id is invalid
- Fix ACL for scriptures and timeline pages
